### PR TITLE
Add macOS specific OpenSSL keyword

### DIFF
--- a/get-keywords/get-keywords
+++ b/get-keywords/get-keywords
@@ -91,7 +91,7 @@ EXAMPLES:
         VERBOSE = args.verbose
 
     #
-    keyword_set = set()
+    keyword_set = set(['usekeychain'])
 
     #
     for arg in args.args:

--- a/ssh-config-keywords.txt
+++ b/ssh-config-keywords.txt
@@ -99,6 +99,7 @@ tisauthentication
 tunnel
 tunneldevice
 updatehostkeys
+usekeychain
 user
 userknownhostsfile
 verifyhostkeydns


### PR DESCRIPTION
Add an extra keyword for macOS' ssh

https://github.com/apple-oss-distributions/OpenSSH/blob/cde919fd5d3fc8bb2ca9709a9ece99737523ec22/openssh/ssh_config.5#L1667

https://github.com/jhgorrell/ssh-config-mode-el/pull/33#issuecomment-1086215347