### PR TITLE
Make known_hosts hostname matching more lenient

### DIFF
--- a/ssh-config-mode.el
+++ b/ssh-config-mode.el
@@ -301,6 +301,17 @@ We permit underscores.")
    ssh-known-hosts-regex-hostname
    "\\)"))
 
+(defvar ssh-known-hosts-regex-hostname-pattern
+  (concat
+   "\\(?:"
+   ssh-known-hosts-regex-hostname
+   "\\|"
+   ssh-known-hosts-regex-ip
+   "\\|"
+   ;; [host-or-ip]:222
+   "\\(?:\\[" ssh-known-hosts-regex-host "\\]:" ssh-known-hosts-regex-port "\\)"
+   "\\)"))
+
 ;; NOTE: font-lock-studio might be of help when making changes.
 (defvar ssh-known-hosts-font-lock-keywords
   ;; We want to match lines like the following:
@@ -320,27 +331,11 @@ We permit underscores.")
        ssh-known-hosts-regex-hashed
        "\\|"
 
-       ;; hostname-only
-       ssh-known-hosts-regex-hostname
-       "\\|"
-
-       ;; ip-only
-       ssh-known-hosts-regex-ip
-       "\\|"
-
-       ;; hostname "," ip
-       "\\(?:" ssh-known-hosts-regex-hostname "," ssh-known-hosts-regex-ip "\\)"
-       "\\|"
-
-       ;; [host-or-ip]:222
-       "\\(?:\\[" ssh-known-hosts-regex-host "\\]:" ssh-known-hosts-regex-port "\\)"
-       "\\|"
-
-       ;; We arent matching ports, but they should be the same.
-       ;; [ssh.github.com]:443,[192.1.2.3]:443
-       "\\(?:"
-       "\\[" ssh-known-hosts-regex-hostname "\\]:" ssh-known-hosts-regex-port ","
-       "\\[" ssh-known-hosts-regex-ip       "\\]:" ssh-known-hosts-regex-port "\\)"
+       ;; list of comma separated hostname patterns
+       ssh-known-hosts-regex-hostname-pattern
+       "\\(?:,"
+       ssh-known-hosts-regex-hostname-pattern
+       "\\)*"
 
        "\\)"
        "[ \t]+"


### PR DESCRIPTION
Documentation for the known_hosts file format specifies "Hostnames is a comma-separated list of patterns [...]". The regexps we had is unnecessariliy strict, allowing only a subset of valid sequences.

Make it more lenient (and simple) to match more valid ones.

https://man.openbsd.org/sshd#SSH_KNOWN_HOSTS_FILE_FORMAT

Wildcard support is still missing, but I'm scratching another itch I have with this (manually crafted entries with hostname followed by more than one IP address).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved hostname pattern recognition in SSH `known_hosts` files.
  * Consolidated support for hostnames, IP addresses, and bracketed host-and-port entries.
  * Preserved highlighting behavior while simplifying pattern handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->