### PR TITLE
added new ssh config keywords

### DIFF
--- a/ssh-config-keywords.txt
+++ b/ssh-config-keywords.txt
@@ -79,6 +79,7 @@ proxyusefdpass
 pubkeyacceptedalgorithms
 pubkeyacceptedkeytypes
 pubkeyauthentication
+refuseconnection
 rekeylimit
 remotecommand
 remoteforward
@@ -110,4 +111,5 @@ userknownhostsfile
 verifyhostkeydns
 versionaddendum
 visualhostkey
+warnweakcrypto
 xauthlocation


### PR DESCRIPTION
Just adding some keywords to ssh_config so that it matches the newer man page (I'm using OpenSSH_10.2p1). 
I have not synchronized the list according to man page, as I assume the keyword list should also contain config options from older OpenSSH versions.